### PR TITLE
(do not merge yet) WIP port to use kappa next

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ function KV (db, mapFn, opts) {
 
     api: {
       get: function (core, key, cb) {
+        const self = this
         this.ready(function () {
           kv.get(key, function (err, ids) {
             if (err) return cb(err)
@@ -58,7 +59,7 @@ function KV (db, mapFn, opts) {
               // TODO: expose this on kappa-core somehow
               // TODO: in fact, can we just expose the 'version' string /w @
               // explicitly?
-              var feed = core._logs.feed(id.split('@')[0])
+              var feed = self.source.feed(id.split('@')[0])
               var seq = Number(id.split('@')[1])
               ;(function (feed, seq) {
                 feed.get(seq, function (err, value) {
@@ -86,12 +87,13 @@ function KV (db, mapFn, opts) {
       },
 
       createReadStream: function (core) {
+        const flow = this
         var t = through.obj(function (entry, _, next) {
           var self = this
           var pending = 1
           var res = entry.value.split(',').forEach(function (value) {
             pending++
-            var feed = core._logs.feed(value.split('@')[0])
+            var feed = flow.source.feed(value.split('@')[0])
             if (feed) {
               var seq = Number(value.split('@')[1])
               feed.get(seq, function (err, val) {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   },
   "devDependencies": {
     "collect-stream": "^1.2.1",
-    "kappa-core": "^2.3.2",
+    "kappa-core": "github:Frando/kappa-core#kappa5-new",
     "level": "^5.0.1",
+    "multifeed": "^5.1.1",
     "random-access-memory": "^3.0.0",
     "sha.js": "^2.4.11",
     "standard": "~10.0.0",


### PR DESCRIPTION
I wrote this to be able to experiment if [kappa-drive](https://ledger-git.dyne.org/CoBox/kappa-drive) would be easy enough to port to the current [kappa-core WIP rewrite](https://github.com/kappa-db/kappa-core/pull/14).

Do not merge! This PR is just so that the code is out somewhere.

Details on why this is needed if the kappa-core next branch should be merged:

kappa-view-kv uses the internal `kappa._logs` property that is the multifeed instance. This of course cannot work if kappa-core is not hardwired to multifeed. Instead, kappa-view-kv now *assumes that its source in the kappa exposes an API method `feed(key)` that returns a hypercore instance for a key*. This `feed` method is implemented both for the multifeed and corestore sources in kappa-core.
